### PR TITLE
feat: Add function to save variables as dictionary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,4 +2,11 @@
 varST(var ➡️ reStructuredText)
 ==============================
 
+|pre-commit.ci status| |Documentation Status|
+
 Replace substitutions in rst files with variables.
+
+.. |pre-commit.ci status| image:: https://results.pre-commit.ci/badge/github/junghoon-vans/varst/main.svg
+   :target: https://results.pre-commit.ci/latest/github/junghoon-vans/varst/main
+.. |Documentation Status| image:: https://readthedocs.org/projects/varst/badge/?version=latest
+    :target: https://varst.readthedocs.io/en/latest/?badge=latest

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,31 @@
+import argparse
+from contextlib import contextmanager
+from typing import Generator
+from typing import Optional
+
+import pytest
+
+
+class ArgparseErrorWrapper:
+    def __init__(self):
+        self._error: Optional[argparse.ArgumentError] = None
+
+    @property
+    def error(self):
+        assert self._error is not None
+        return self._error
+
+    @error.setter
+    def error(self, value: object):
+        assert isinstance(value, argparse.ArgumentError)
+        self._error = value
+
+
+@contextmanager
+def argparse_error() -> Generator[ArgparseErrorWrapper, None, None]:
+    wrapper = ArgparseErrorWrapper()
+
+    with pytest.raises(SystemExit) as e:
+        yield wrapper
+
+    wrapper.error = e.value.__context__

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -9,21 +9,20 @@ def parser() -> Parser:
     return parser
 
 
-def test_parse_args(parser: Parser):
+def test_parse_without_file_path(parser: Parser):
+    parser.parse([
+        'varst=variable to reStructuredText',
+    ])
 
-    assert parser.parse_args_dict(['varst=variable to reStructuredText']) == {
-        'variables': ['varst=variable to reStructuredText'],
-        'input': './README.rst',
-        'output': './README.rst',
-    }
+    assert parser.variables == ['varst=variable to reStructuredText']
+    assert parser.input_file == './README.rst'
+    assert parser.output_file == './README.rst'
 
-    assert parser.parse_args_dict(
-        [
-            'varst=variable to reStructuredText',
-            '-i=./CHANGELOG.rst', '-o=./CHANGELOG.rst',
-        ],
-    ) == {
-        'variables': ['varst=variable to reStructuredText'],
-        'input': './CHANGELOG.rst',
-        'output': './CHANGELOG.rst',
-    }
+
+def test_parse_with_file_path(parser: Parser):
+    parser.parse([
+        '-i=./CHANGELOG.rst', '-o=./CHANGELOG.rst',
+    ])
+
+    assert parser.input_file == './CHANGELOG.rst'
+    assert parser.output_file == './CHANGELOG.rst'

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -46,3 +46,8 @@ def test_parse_one_element(parser: Parser):
         parser.parse(['key='])
     with argparse_error():
         parser.parse(['=value'])
+
+
+def test_parse_more_than_two_element(parser: Parser):
+    with argparse_error():
+        parser.parse(['key=value=else'])

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -1,18 +1,20 @@
+from typing import Generator
+
 import pytest
 
 from tests.utils import argparse_error
 from varst.utils.parser import Parser
 
 
-@pytest.fixture
-def parser() -> Parser:
+@pytest.fixture(scope="session")
+def parser() -> Generator[Parser, None, None]:
     parser = Parser()
     parser.parse([
         'varst=variable to reStructuredText',
         'version=0.2.0',
         'release=v0.2.0',
     ])
-    return parser
+    yield parser
 
 
 def test_parse_variables(parser: Parser):

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -14,7 +14,7 @@ def test_parse_without_file_path(parser: Parser):
         'varst=variable to reStructuredText',
     ])
 
-    assert parser.variables == ['varst=variable to reStructuredText']
+    assert parser.variables == {'varst': 'variable to reStructuredText'}
     assert parser.input_file == './README.rst'
     assert parser.output_file == './README.rst'
 

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.utils import argparse_error
 from varst.utils.parser import Parser
 
 
@@ -34,3 +35,8 @@ def test_parse_with_file_path(parser: Parser):
 
     assert parser.input_file == './CHANGELOG.rst'
     assert parser.output_file == './CHANGELOG.rst'
+
+
+def test_parse_one_element(parser: Parser):
+    with argparse_error():
+        parser.parse(['one'])

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -6,15 +6,23 @@ from varst.utils.parser import Parser
 @pytest.fixture
 def parser() -> Parser:
     parser = Parser()
+    parser.parse([
+        'varst=variable to reStructuredText',
+        'version=0.2.0',
+        'release=v0.2.0',
+    ])
     return parser
 
 
-def test_parse_without_file_path(parser: Parser):
-    parser.parse([
-        'varst=variable to reStructuredText',
-    ])
+def test_parse_variables(parser: Parser):
+    assert parser.variables == {
+        'varst': 'variable to reStructuredText',
+        'version': '0.2.0',
+        'release': 'v0.2.0',
+    }
 
-    assert parser.variables == {'varst': 'variable to reStructuredText'}
+
+def test_parse_without_file_path(parser: Parser):
     assert parser.input_file == './README.rst'
     assert parser.output_file == './README.rst'
 

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -42,3 +42,7 @@ def test_parse_with_file_path(parser: Parser):
 def test_parse_one_element(parser: Parser):
     with argparse_error():
         parser.parse(['one'])
+    with argparse_error():
+        parser.parse(['key='])
+    with argparse_error():
+        parser.parse(['=value'])

--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -51,3 +51,12 @@ def test_parse_one_element(parser: Parser):
 def test_parse_more_than_two_element(parser: Parser):
     with argparse_error():
         parser.parse(['key=value=else'])
+
+
+def test_parse_many_equals(parser: Parser):
+    with argparse_error():
+        parser.parse(['key==value'])
+    with argparse_error():
+        parser.parse(['key===value'])
+    with argparse_error():
+        parser.parse(['key====value'])

--- a/varst/application.py
+++ b/varst/application.py
@@ -18,5 +18,4 @@ class Application:
                 argv: Arguments vector
 
         """
-        args_dict = self.parser.parse_args_dict(argv)
-        print(args_dict)
+        self.parser.parse(argv)

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -1,7 +1,15 @@
+import argparse
+import re
 from argparse import ArgumentParser
 from typing import Any
 from typing import Optional
 from typing import Sequence
+
+
+def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]=[a-zA-Z]")):
+    if not pat.match(arg_value):
+        raise argparse.ArgumentTypeError("invalid value")
+    return arg_value
 
 
 class Parser:
@@ -12,6 +20,7 @@ class Parser:
         self._parser.add_argument(
             "variables", nargs="*",
             help="key-value pairs of substitutions",
+            type=_variable_type,
         )
         self._parser.add_argument(
             "-i",

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -45,7 +45,7 @@ class Parser:
         self.variables = _parse_kv(arg_dict['variables'])
 
 
-def _pattern_type(arg_value: str, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
+def _pattern_type(arg_value: str, pat=re.compile(r".*=.*")):
     """
         Args:
             arg_value: The string value to check pattern.

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 from argparse import ArgumentParser
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -12,13 +13,31 @@ def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
     return arg_value
 
 
+def _parse_kv(variables: List[str]) -> Dict[str, str]:
+    """Parse ``key-value`` pair from variables.
+
+        Args:
+            variables: The string list to be parsed.
+        Returns:
+            Dict[str, str]: key-value pair
+
+    """
+    result: Dict[str, str] = {}
+
+    for variable in variables:
+        kv = variable.split("=")
+        result[kv.pop()] = kv.pop()
+
+    return result
+
+
 class Parser:
 
     _parser = ArgumentParser()
 
     input_file: str = ""
     output_file: str = ""
-    variables: List[str] = []
+    variables: Dict[str, str] = {}
 
     def __init__(self) -> None:
         self._parser.add_argument(
@@ -47,4 +66,4 @@ class Parser:
 
         self.input_file = arg_dict['input']
         self.output_file = arg_dict['output']
-        self.variables = arg_dict['variables']
+        self.variables = _parse_kv(arg_dict['variables'])

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 
 class Parser:
+    """Parser class that parse arguments from cli"""
 
     _parser = ArgumentParser()
 
@@ -37,6 +38,13 @@ class Parser:
         )
 
     def parse(self, argv: Optional[Sequence[str]]) -> None:
+        """ Parse the arguments from argv.
+            Parsed values are updated in the attributes of the parser.
+
+            Args:
+                argv: Arguments vector
+
+        """
         args = self._parser.parse_args(argv)
         arg_dict = vars(args)
 

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -19,7 +19,7 @@ class Parser:
         self._parser.add_argument(
             "variables", nargs="*",
             help="key-value pairs of substitutions",
-            type=_variable_type,
+            type=_pattern_type,
         )
         self._parser.add_argument(
             "-i",
@@ -45,9 +45,17 @@ class Parser:
         self.variables = _parse_kv(arg_dict['variables'])
 
 
-def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
+def _pattern_type(arg_value: str, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
+    """
+        Args:
+            arg_value: The string value to check pattern.
+            pat: The pattern to match value.
+        Returns:
+            str: Returns arg_value that matched with pattern.
+
+    """
     if not pat.match(arg_value):
-        raise argparse.ArgumentTypeError("invalid value")
+        raise argparse.ArgumentTypeError(f"invalid pattern {pat}")
     return arg_value
 
 

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -49,7 +49,8 @@ _VARIABLE_PATTERN = re.compile(r"[^=]+=[^=]+")
 
 
 def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
-    """
+    """ Verify that the arg_value fully matches the pattern.
+
         Args:
             arg_value: The string value to check pattern.
             pat: The pattern to match value.

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -72,7 +72,7 @@ def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
 
 
 def _parse_kv(variables: List[str]) -> Dict[str, str]:
-    """Parse ``key-value`` pair from variables.
+    """ Parse ``key-value`` pair from variables.
 
         Args:
             variables: The string list to be parsed.

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -6,7 +6,7 @@ from typing import Optional
 from typing import Sequence
 
 
-def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]=[a-zA-Z]")):
+def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
     if not pat.match(arg_value):
         raise argparse.ArgumentTypeError("invalid value")
     return arg_value

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -7,30 +7,6 @@ from typing import Optional
 from typing import Sequence
 
 
-def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
-    if not pat.match(arg_value):
-        raise argparse.ArgumentTypeError("invalid value")
-    return arg_value
-
-
-def _parse_kv(variables: List[str]) -> Dict[str, str]:
-    """Parse ``key-value`` pair from variables.
-
-        Args:
-            variables: The string list to be parsed.
-        Returns:
-            Dict[str, str]: key-value pair
-
-    """
-    result: Dict[str, str] = {}
-
-    for variable in variables:
-        kv = variable.split("=")
-        result[kv.pop()] = kv.pop()
-
-    return result
-
-
 class Parser:
 
     _parser = ArgumentParser()
@@ -67,3 +43,27 @@ class Parser:
         self.input_file = arg_dict['input']
         self.output_file = arg_dict['output']
         self.variables = _parse_kv(arg_dict['variables'])
+
+
+def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]+=[a-zA-Z]+")):
+    if not pat.match(arg_value):
+        raise argparse.ArgumentTypeError("invalid value")
+    return arg_value
+
+
+def _parse_kv(variables: List[str]) -> Dict[str, str]:
+    """Parse ``key-value`` pair from variables.
+
+        Args:
+            variables: The string list to be parsed.
+        Returns:
+            Dict[str, str]: key-value pair
+
+    """
+    result: Dict[str, str] = {}
+
+    for variable in variables:
+        kv = variable.split("=")
+        result[kv.pop()] = kv.pop()
+
+    return result

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -58,7 +58,7 @@ def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
 
     """
     if not pat.match(arg_value):
-        raise argparse.ArgumentTypeError(f"invalid pattern {pat}")
+        raise argparse.ArgumentTypeError(f"invalid pattern: {pat.pattern}")
     return arg_value
 
 

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -45,7 +45,10 @@ class Parser:
         self.variables = _parse_kv(arg_dict['variables'])
 
 
-def _pattern_type(arg_value: str, pat=re.compile(r".*=.*")):
+_VARIABLE_PATTERN = re.compile(r".*=.*")
+
+
+def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
     """
         Args:
             arg_value: The string value to check pattern.

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -45,7 +45,7 @@ class Parser:
         self.variables = _parse_kv(arg_dict['variables'])
 
 
-_VARIABLE_PATTERN = re.compile(r".*=.*")
+_VARIABLE_PATTERN = re.compile(r"[^=]+=[^=]+")
 
 
 def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
@@ -57,7 +57,7 @@ def _pattern_type(arg_value: str, pat=_VARIABLE_PATTERN):
             str: Returns arg_value that matched with pattern.
 
     """
-    if not pat.match(arg_value):
+    if not pat.fullmatch(arg_value):
         raise argparse.ArgumentTypeError(f"invalid pattern: {pat.pattern}")
     return arg_value
 

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 from argparse import ArgumentParser
-from typing import Any
+from typing import List
 from typing import Optional
 from typing import Sequence
 
@@ -15,6 +15,10 @@ def _variable_type(arg_value, pat=re.compile(r"[a-zA-Z]=[a-zA-Z]")):
 class Parser:
 
     _parser = ArgumentParser()
+
+    input_file: str = ""
+    output_file: str = ""
+    variables: List[str] = []
 
     def __init__(self) -> None:
         self._parser.add_argument(
@@ -37,6 +41,10 @@ class Parser:
             default="./README.rst",
         )
 
-    def parse_args_dict(self, argv: Optional[Sequence[str]]) -> dict[str, Any]:
+    def parse(self, argv: Optional[Sequence[str]]) -> None:
         args = self._parser.parse_args(argv)
-        return vars(args)
+        arg_dict = vars(args)
+
+        self.input_file = arg_dict['input']
+        self.output_file = arg_dict['output']
+        self.variables = arg_dict['variables']


### PR DESCRIPTION
Changes
---

- Implement `parse` function.
  - parse the arguments and save that as properties of `Parser` class.
- Implement `_pattern_type` function.
  - check the pattern of variable to throw `ArgumentTypeError`.
- Implement `_parse_kv` function.
  - convert arguments to dictionary formatted `key-value`.
- Add test case to check handling of `ArgumentTypeError`.
- Implement `ArgparseErrorWrapper` to check `ArgumentTypeError` in pytest.