### PR TITLE
fix: Resolve error that cannot find variable name with whitespace

### DIFF
--- a/tests/data/README.rst
+++ b/tests/data/README.rst
@@ -1,6 +1,7 @@
 Substitution Test
 =================
 
-replace: |status|
+replace: |status|, with space: |with whitespace|
 
 .. |status| replace:: false
+.. |with whitespace| replace:: false

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -21,6 +21,8 @@ def substitution() -> Substitution:
 def test_find_substitution(substitution: Substitution):
     content = substitution.find("status")
     print(content)
+    content = substitution.find("with whitespace")
+    print(content)
 
     with pytest.raises(KeyError):
         substitution.find("state")

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -19,13 +19,14 @@ def substitution() -> Substitution:
 
 
 def test_find_substitution(substitution: Substitution):
-    content = substitution.find("status")
-    print(content)
-    content = substitution.find("with whitespace")
-    print(content)
+    none_whitespace = substitution.find("status")
+    with_whitespace = substitution.find("with whitespace")
+
+    print(none_whitespace)
+    print(with_whitespace)
 
     with pytest.raises(KeyError):
-        substitution.find("state")
+        substitution.find("not exist name")
 
 
 def test_create_substitution():

--- a/varst/utils/substitution.py
+++ b/varst/utils/substitution.py
@@ -19,16 +19,10 @@ class Substitution:
             KeyError: If substitution is not in file.
 
         """
-        pattern = re.compile(
-            fr"""
-                \.\.[ ]+          # explicit markup start
-                \|                # substitution indicator
-                ({name})\|        # substitution name
-            """, re.VERBOSE,
-        )
+        pattern = fr"""\.\.[ ]+\|({name})\|"""
 
         for content in self.rst_file.contents:
-            if pattern.match(content):
+            if re.match(pattern, content):
                 return content
         raise KeyError(name)
 


### PR DESCRIPTION
Related issue
---

Keyerror occurs when name of substitution has whitespace. #19

Changes
---

- Update regex to resolve problems with name of substitution has whitespace
- Update test case to find substitution with whitespace

Note
---

If substitution name has whitespace, It must be enclosed in quotes(single or double).

Examples are as follows:

```bash
$ varst -i path/to/your.rst -o path/to/your.rst 'with whitespace'=value
$ varst -i path/to/your.rst -o path/to/your.rst 'with whitespace'='value with whitespace'
$ varst -i path/to/your.rst -o path/to/your.rst 'with whitespace=value with whitespace'
```
