### PR TITLE
feat: Running application with only input path

### DIFF
--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -17,8 +17,8 @@ def parser() -> Generator[Parser, None, None]:
     yield parser
 
 
-def test_parse_variables(parser: Parser):
-    assert parser.variables == {
+def test_parse_sub_pairs(parser: Parser):
+    assert parser.sub_pairs == {
         'varst': 'variable to reStructuredText',
         'version': '0.2.0',
         'release': 'v0.2.0',

--- a/varst/application.py
+++ b/varst/application.py
@@ -24,6 +24,6 @@ class Application:
 
         rst_file = RstFile(src=self.parser.input_file)
         substitution = Substitution(rst_file)
-        for k, v in self.parser.variables.items():
+        for k, v in self.parser.sub_pairs.items():
             substitution.update(k, v)
         rst_file.save(dest=self.parser.output_file)

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -17,7 +17,7 @@ class Parser:
 
     input_file: str = ""
     output_file: str = ""
-    variables: Dict[str, str] = {}
+    sub_pairs: Dict[str, str] = {}
 
     def __init__(self) -> None:
         self._parser.add_argument(
@@ -53,7 +53,7 @@ class Parser:
         self.input_file = self.output_file = arg_dict['input']
         if arg_dict['output'] is not None:
             self.output_file = arg_dict['output']
-        self.variables = _parse_kv(arg_dict['name=value'])
+        self.sub_pairs = _parse_kv(arg_dict['name=value'])
 
 
 _VARIABLE_PATTERN = re.compile(r"[^=]+=[^=]+")

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -13,13 +13,12 @@ from varst import supported
 class Parser:
     """Parser class that parse arguments from cli"""
 
-    _parser = ArgumentParser()
-
-    input_file: str = ""
-    output_file: str = ""
-    sub_pairs: Dict[str, str] = {}
-
     def __init__(self) -> None:
+        self._parser = ArgumentParser()
+        self.input_file: str = ""
+        self.output_file: str = ""
+        self.sub_pairs: Dict[str, str] = {}
+
         self._parser.add_argument(
             "name=value", nargs="*",
             help="name-value pairs of substitutions",

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -37,7 +37,6 @@ class Parser:
             "--output",
             type=_file_type,
             help="rst file path as output",
-            default="./README.rst",
         )
 
     def parse(self, argv: Optional[Sequence[str]]) -> None:
@@ -51,8 +50,9 @@ class Parser:
         args = self._parser.parse_args(argv)
         arg_dict = vars(args)
 
-        self.input_file = arg_dict['input']
-        self.output_file = arg_dict['output']
+        self.input_file = self.output_file = arg_dict['input']
+        if arg_dict['output'] is not None:
+            self.output_file = arg_dict['output']
         self.variables = _parse_kv(arg_dict['name=value'])
 
 


### PR DESCRIPTION
If the `output-file` is not specified, the `input-file` is set to default.
For example, the following is possible.

```bash
$ varst -i path/to/your.rst 'sub name=new value'
```

