### PR TITLE
feat: Support directive type of none replacement text

### DIFF
--- a/tests/data/README.rst
+++ b/tests/data/README.rst
@@ -1,9 +1,17 @@
-Substitution Test
-=================
+Substitution Definitions
+========================
 
-replace: |status|, with space: |with whitespace|, image: |badge|
+|logo|
 
-.. |status| replace:: false
-.. |with whitespace| replace:: false
-.. |badge| image:: https://img.shields.io/badge/test-fail-red
-   :target: https://pypi.org/project/varst/
+|RST|_ is a little annoying to type over and over, especially
+when writing about |RST| itself, and spelling out the
+bicapitalized word |RST| every time isn't really necessary for
+|RST| source readability.
+
+
+.. |logo| image:: https://docutils.sourceforge.io/rst.png
+   :alt: reStructuredText logo
+   :target: https://docutils.sourceforge.io/rst.html
+
+.. |RST| replace:: reStructuredText
+.. _RST: https://docutils.sourceforge.io/rst.html

--- a/tests/data/README.rst
+++ b/tests/data/README.rst
@@ -1,7 +1,9 @@
 Substitution Test
 =================
 
-replace: |status|, with space: |with whitespace|
+replace: |status|, with space: |with whitespace|, image: |badge|
 
 .. |status| replace:: false
 .. |with whitespace| replace:: false
+.. |badge| image:: https://img.shields.io/badge/test-fail-red
+   :target: https://pypi.org/project/varst/

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -20,26 +20,23 @@ def substitution() -> Substitution:
 
 
 def test_find_substitution(substitution: Substitution):
-    none_whitespace = substitution.find("status")
-    with_whitespace = substitution.find("with whitespace")
+    full_name = substitution.find("RST")
+    logo_image = substitution.find("logo")
 
-    print(none_whitespace)
-    print(with_whitespace)
+    print(full_name)
+    print(logo_image)
 
     with pytest.raises(KeyError):
         substitution.find("not exist name")
 
 
 def test_update_substitution(substitution: Substitution):
-    substitution.update("status", "true")
-    substitution.update("with whitespace", "true")
-    substitution.update("badge", "success")
+    substitution.update("RST", "rst")
+    substitution.update("logo", "https://example.com/")
 
-    assert substitution.find("status") == """.. |status| replace:: true\n"""
-    assert substitution.find(
-        "with whitespace",
-    ) == """.. |with whitespace| replace:: true\n"""
-    assert substitution.find("badge") == """.. |badge| image:: success\n"""
+    assert substitution.find("RST") == """.. |RST| replace:: rst\n"""
+    assert substitution.find("logo")\
+        == """.. |logo| image:: https://example.com/\n"""
 
 
 def test_create_substitution():

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -44,5 +44,11 @@ def test_create_substitution():
 
 
 def test_directive_type():
-    substitution = ".. |badge| image:: https://example.com/"
-    assert directive_type(substitution) == "image"
+    replacement_text_type = ".. |RST| replace:: reStructuredText"
+    assert directive_type(replacement_text_type) == "replace"
+
+    image_type = ".. |badge| image:: https://example.com/"
+    assert directive_type(image_type) == "image"
+
+    object_type = ".. |The Transparent Society| book:: isbn=0738201448"
+    assert directive_type(object_type) == "book"

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -32,11 +32,13 @@ def test_find_substitution(substitution: Substitution):
 def test_update_substitution(substitution: Substitution):
     substitution.update("status", "true")
     substitution.update("with whitespace", "true")
+    substitution.update("badge", "success")
 
     assert substitution.find("status") == """.. |status| replace:: true\n"""
     assert substitution.find(
         "with whitespace",
     ) == """.. |with whitespace| replace:: true\n"""
+    assert substitution.find("badge") == """.. |badge| image:: success\n"""
 
 
 def test_create_substitution():

--- a/tests/utils/test_substitution.py
+++ b/tests/utils/test_substitution.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from varst.utils.rst_file import RstFile
+from varst.utils.substitution import directive_type
 from varst.utils.substitution import Substitution
 from varst.utils.substitution import substitution_def
 
@@ -43,3 +44,8 @@ def test_update_substitution(substitution: Substitution):
 
 def test_create_substitution():
     assert substitution_def("key", "value") == """.. |key| replace:: value"""
+
+
+def test_directive_type():
+    substitution = ".. |badge| image:: https://example.com/"
+    assert directive_type(substitution) == "image"

--- a/varst/utils/substitution.py
+++ b/varst/utils/substitution.py
@@ -1,4 +1,6 @@
 import re
+from typing import Match
+from typing import Optional
 
 from varst.utils.rst_file import RstFile
 
@@ -57,3 +59,22 @@ def substitution_def(
 
     """
     return f'.. |{text}| {directive}:: {data}'
+
+
+def directive_type(substitution: str) -> str:
+    """Get directive type from substitution definition.
+
+    Args:
+        substitution: The string value of substitution definition.
+    Returns:
+        Returns directive type.
+    Raises:
+        ValueError: If directive type is not valid.
+
+    """
+
+    pattern = r"""\|(.*)\|(.*?)::"""
+    result: Optional[Match[str]] = re.search(pattern, substitution)
+    if result:
+        return result.group(2).strip()
+    raise ValueError("directive type is not valid")

--- a/varst/utils/substitution.py
+++ b/varst/utils/substitution.py
@@ -37,7 +37,7 @@ class Substitution:
 
         """
         origin = self.find(text)
-        new = substitution_def(text, data)
+        new = substitution_def(text, data, directive_type(origin))
 
         origin_idx = self.rst_file.contents.index(origin)
         self.rst_file.contents.pop(origin_idx)

--- a/varst/utils/substitution.py
+++ b/varst/utils/substitution.py
@@ -42,14 +42,18 @@ class Substitution:
         self.rst_file.contents.insert(origin_idx, new + "\n")
 
 
-def substitution_def(text: str, data: str) -> str:
+def substitution_def(
+    text: str, data: str,
+    directive: str = 'replace',
+) -> str:
     """Create substitution definition by using substitution text and data.
 
     Args:
         text: The string value of substitution text.
         data: The string value of substitution data.
+        directive: The string value of directive type.
     Returns:
         Returns substitution definition.
 
     """
-    return f'.. |{text}| replace:: {data}'
+    return f'.. |{text}| {directive}:: {data}'


### PR DESCRIPTION
Feature
---

All `directive types` for substitution are now supported. #29
For more information on direct types, see the [reStructured Markup Specification](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#substitution-definitions)

### Example

```bash
$ varst -i input.rst -o output.rst 'image url=https://example.com/new-image.png'
```

If you want to modify the image url, perform the following command.

```diff
- .. |image url| image:: https://example.com/old-image.png
+ .. |image url| image:: https://example.com/new-image.png
```