### PR TITLE
feat: Add error handling if substitutions are not provided

### DIFF
--- a/tests/utils/test_parser.py
+++ b/tests/utils/test_parser.py
@@ -32,8 +32,14 @@ def test_parse_without_file_path(parser: Parser):
     assert parser.output_file == './README.rst'
 
 
+def test_parse_without_substitutions(parser: Parser):
+    with pytest.raises(ValueError):
+        parser.parse(['-i=./CHANGELOG.rst', '-o=./CHANGELOG.rst'])
+
+
 def test_parse_with_file_path(parser: Parser):
     parser.parse([
+        'varst=variable to reStructuredText',
         '-i=./CHANGELOG.rst', '-o=./CHANGELOG.rst',
     ])
 

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -51,6 +51,8 @@ class Parser:
 
         Args:
             argv: Arguments vector
+        Raises:
+            ValueError: If the substitutions are not passed
 
         """
         args = self._parser.parse_args(argv)

--- a/varst/utils/parser.py
+++ b/varst/utils/parser.py
@@ -59,6 +59,10 @@ class Parser:
         self.input_file = self.output_file = arg_dict['input']
         if arg_dict['output'] is not None:
             self.output_file = arg_dict['output']
+
+        substitutions = arg_dict['substitutions']
+        if not substitutions:
+            raise ValueError("Substitutions are not passed")
         self.sub_pairs = _parse_kv(arg_dict['substitutions'])
 
 


### PR DESCRIPTION
## Related Issue

#54 

## Description

Make parser raise an `ValueError` when substitutions are not passed.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Tests
- [X] Documentation
- [ ] CI
- [ ] Performance
- [ ] Other

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
